### PR TITLE
Fix compilation issues on OTP 23+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ otp_release:
    - 21.3
    - 22.3
    - 23.1
-script: >
-  curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3
-  && ./rebar3 do xref, eunit, ct, dialyze
+script: rebar3 do xref, eunit, ct, dialyze

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ otp_release:
    - 21.3
    - 22.3
    - 23.1
-script: rebar3 do xref, eunit, ct, dialyze
+script: >
+  curl https://s3.amazonaws.com/rebar3/rebar3 -o rebar3
+  && ./rebar3 do xref, eunit, ct, dialyze

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ otp_release:
    - 20.3
    - 21.3
    - 22.3
-   - 23.1
+   - 23.0
 script: rebar3 do xref, eunit, ct, dialyzer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-before_install:
-   - sudo apt-get update
-   - sudo apt-get install libicu-dev libmozjs-dev
-before_script: ./bootstrap && ./configure
-script: make distcheck
+sudo: false
 language: erlang
 otp_release:
-   - R15B02
-   - R15B01
-   - R15B
-   - R14B04
-   - R14B03
+   - 19.3
+   - 20.3
+   - 21.3
+   - 22.3
+   - 23.1
+script: rebar3 do xref, eunit, ct, dialyze

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ otp_release:
    - 21.3
    - 22.3
    - 23.1
-script: rebar3 do xref, eunit, ct, dialyze
+script: rebar3 do xref, eunit, ct, dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,7 @@
 %% ex: ts=4 sw=4 ft=erlang noet
 
 {erl_opts, [
+	debug_info,
 	{platform_define, "^(R|1|(20)|(21)|(22.0))", old_hmac_api}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,9 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang noet
 
+{erl_opts, [
+	{platform_define, "^(R|1|(20)|(21)|(22.0))", old_hmac_api}
+]}.
 
 %% Require at least R14B03. (couchdb requires this version or newer, and this code hasn't been tested on earlier)
 {require_min_otp_vsn, "R14B03"}.

--- a/src/pbkdf2.app.src
+++ b/src/pbkdf2.app.src
@@ -2,7 +2,7 @@
 	{description, "Erlang PBKDF2 Key Derivation Function"},
 	{vsn, git},
 	{registered, []},
-	{applications, [kernel, stdlib]},
+	{applications, [kernel, stdlib, crypto]},
 	{modules, [pbkdf2]},
 	{env, []}
 ]}.

--- a/src/pbkdf2.erl
+++ b/src/pbkdf2.erl
@@ -137,9 +137,9 @@ pbkdf2(MacFunc, Password, Salt, Iterations, BlockIndex, Iteration, Prev, Acc) ->
 resolve_mac_func({hmac, DigestFunc}) ->
 	fun(Key, Data) ->
 		%crypto:hmac(DigestFunc, Key, Data)
-		HMAC = crypto:hmac_init(DigestFunc, Key),
-		HMAC1 = crypto:hmac_update(HMAC, Data),
-		crypto:hmac_final(HMAC1)
+		HMAC = hmac_init(DigestFunc, Key),
+		HMAC1 = hmac_update(HMAC, Data),
+		hmac_final(HMAC1)
 	end;
 
 resolve_mac_func(MacFunc) when is_function(MacFunc) ->
@@ -153,6 +153,28 @@ resolve_mac_func(sha224) -> resolve_mac_func({hmac, sha224});
 resolve_mac_func(sha256) -> resolve_mac_func({hmac, sha256});
 resolve_mac_func(sha384) -> resolve_mac_func({hmac, sha384});
 resolve_mac_func(sha512) -> resolve_mac_func({hmac, sha512}).
+
+-ifdef(old_hmac_api).
+hmac_init(Type, Key) ->
+    crypto:hmac_init(Type, Key).
+
+hmac_update(State, Data) ->
+    crypto:hmac_update(State, Data).
+
+hmac_final(State) ->
+    crypto:hmac_final(State).
+
+-else.
+hmac_init(Type, Key) ->
+    crypto:mac_init(hmac, Type, Key).
+
+hmac_update(State, Data) ->
+    crypto:mac_update(State, Data).
+
+hmac_final(State) ->
+    crypto:mac_final(State).
+
+-endif.
 
 %----------------------------------------------------------------------------------------------------------------------
 

--- a/test/pbkdf2_tests.erl
+++ b/test/pbkdf2_tests.erl
@@ -25,9 +25,12 @@
 	{[sha, <<"passwordPASSWORDpassword">>, <<"saltSALTsaltSALTsaltSALTsaltSALTsalt">>, 4096, 25],
 			<<"3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038">>},
 	{[sha, <<"pass\0word">>, <<"sa\0lt">>, 4096, 16],
-			<<"56fa6aa75548099dcc37d7f03425e0c3">>},
-	{[sha, <<"password">>, <<"salt">>, 16777216, 20],
-			<<"eefe3d61cd4da4e4e9945b3d6ba2158c2634e984">>}
+			<<"56fa6aa75548099dcc37d7f03425e0c3">>}
+
+	%% XXX: The following vector takes an impractical amount of time to test.
+	%%      Uncomment as needed.
+	% {[sha, <<"password">>, <<"salt">>, 16777216, 20],
+	% 		<<"eefe3d61cd4da4e4e9945b3d6ba2158c2634e984">>}
 ]).
 
 


### PR DESCRIPTION
Use the [new crypto HMAC API](http://erlang.org/doc/man/crypto.html#mac-3) on recent OTP versions, following the deprecation of the [old one](http://erlang.org/doc/man/crypto.html#hmac-3).